### PR TITLE
Fix Auto‑suggestion wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 **Feature Ideas We'd Love to See:**
 - ~~Tag system for notes~~
 - ~~Easy copy notes~~
-- ~~Autosuggestions commands~~
+- ~~Auto‑suggestion commands~~
 - ~~Rich text formatting~~
 - Cloud sync options
 - Reminder functionality


### PR DESCRIPTION
## Summary
- fix a typo in the README's feature list

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
