### PR TITLE
Fix packaging lint issues

### DIFF
--- a/QuickNotes-1.0.8-arm64.zip.sha256
+++ b/QuickNotes-1.0.8-arm64.zip.sha256
@@ -1,0 +1,1 @@
+27ccca1bdfd83844301da68a3dfcd5854fad6c96322cf613b7a4b49dfa019c00  QuickNotes-1.0.8-arm64.zip

--- a/QuickNotes-1.0.8-x64.zip.sha256
+++ b/QuickNotes-1.0.8-x64.zip.sha256
@@ -1,0 +1,1 @@
+f69e72fdf4088a61c6f0c909f3fb1eaa52c6223d46aa0adccee8a63af2e7125b  QuickNotes-1.0.8-x64.zip

--- a/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes.csproj
+++ b/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes.csproj
@@ -53,4 +53,15 @@
       " />
     </ItemGroup>
   </Target>
+
+  <!-- Remove unnecessary DLLs from build output for packaging -->
+  <Target Name="RemovePowerToysDlls" AfterTargets="Build">
+    <ItemGroup>
+      <UnwantedFiles Include="$(OutputPath)PowerToys.*.dll" />
+      <UnwantedFiles Include="$(OutputPath)PowerToys.*.pdb" />
+      <UnwantedFiles Include="$(OutputPath)Wox.*.dll" />
+      <UnwantedFiles Include="$(OutputPath)Wox.*.pdb" />
+    </ItemGroup>
+    <Delete Files="@(UnwantedFiles)" />
+  </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
   </div>
 </div>
 
+<!-- SHA256 checksums for verification -->
+<details>
+<summary>SHA256 Checksums</summary>
+
+```text
+f69e72fdf4088a61c6f0c909f3fb1eaa52c6223d46aa0adccee8a63af2e7125b  QuickNotes-1.0.8-x64.zip
+27ccca1bdfd83844301da68a3dfcd5854fad6c96322cf613b7a4b49dfa019c00  QuickNotes-1.0.8-arm64.zip
+```
+</details>
+
 <div align="center">
   <h1>✨ QuickNotes for PowerToys Run ✨</h1>
   <h3>Create, manage, and search notes directly from PowerToys Run</h3>


### PR DESCRIPTION
## Summary
- remove PowerToys and Wox DLLs/pdb files after build so packages exclude them
- add SHA256 checksum files for release packages
- document the checksum values in the README

## Testing
- `dotnet build QuickNotes/QuickNotes.sln -c Release -p:Platform=x64`
- `dotnet build QuickNotes/QuickNotes.sln -c Release -p:Platform=ARM64`
- `dotnet test QuickNotes/QuickNotes.sln -p:Platform=x64` *(fails: missing Microsoft.WindowsDesktop.App runtime)*

------
https://chatgpt.com/codex/tasks/task_e_686518429d70832293b8b4dad556dfa8