### PR TITLE
feat: allow custom note file path via environment variable

### DIFF
--- a/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Main.cs
+++ b/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Main.cs
@@ -97,6 +97,7 @@ namespace Community.PowerToys.Run.Plugin.QuickNotes
         public static string PluginID => "2083308C581F4D36B0C02E69A2FD91D7";
         private static readonly Regex UrlRegex = new Regex(@"\b(https?://|www\.)\S+\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private const string NotesFileName = "notes.txt"; // Центральний файл
+        private const string CUSTOM_PATH_ENV_VAR = "QUICKNOTES_CUSTOM_PATH";
 
         // --- Properties ---
         public string Name => "QuickNotes";
@@ -265,7 +266,11 @@ namespace Community.PowerToys.Run.Plugin.QuickNotes
                 UpdateIconPath(Context.API.GetCurrentTheme());
                 Context.API.ThemeChanged += OnThemeChanged;
 
-                var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                var customPath = Environment.GetEnvironmentVariable(CUSTOM_PATH_ENV_VAR);
+                var appDataPath = string.IsNullOrEmpty(customPath)
+                    ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+                    : customPath;
+                    
                 var powerToysPath = Path.Combine(appDataPath, "Microsoft", "PowerToys", "QuickNotes");
                 if (!Directory.Exists(powerToysPath))
                     Directory.CreateDirectory(powerToysPath);


### PR DESCRIPTION
## Add customizable storage location via environment variable

### What this PR does: 
This PR adds the ability to customize the storage location for QuickNotes using an environment variable.

### How to use: 
1. Set the environment variable `QUICKNOTES_CUSTOM_PATH` to your desired path.
2. Restart PowerToys for the changes to take effect. 

### Why this is useful:
This change allows users to specify their own storage location, providing more flexibility and control over where their notes are stored. 

### Example: 

```bash 
set QUICKNOTES_CUSTOM_PATH=C:\MyCustomNotes
```
Or via PowerToys

Double-click to open PowerToys. Find the Quick Access section on the app's home screen. Click on "Open Environment
Variables"
<br>
<img width="457" height="483" alt="image" src="https://github.com/user-attachments/assets/fe7e1eeb-674a-49ed-8336-29110489671c" />
<br>
On User(for personal use) or System (for everyone) click on "Add variable"
<br>
<img width="461" height="387" alt="image" src="https://github.com/user-attachments/assets/8fb367c3-4cdc-4a87-95cf-1d7569ca6031" />


