### PR TITLE
fix: prevent redundant folders when using custom notes path

### DIFF
--- a/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Main.cs
+++ b/QuickNotes/Community.PowerToys.Run.Plugin.QuickNotes/Main.cs
@@ -267,11 +267,11 @@ namespace Community.PowerToys.Run.Plugin.QuickNotes
                 Context.API.ThemeChanged += OnThemeChanged;
 
                 var customPath = Environment.GetEnvironmentVariable(CUSTOM_PATH_ENV_VAR);
-                var appDataPath = string.IsNullOrEmpty(customPath)
-                    ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+                var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                var powerToysPath = string.IsNullOrEmpty(customPath)
+                    ? Path.Combine(appDataPath, "Microsoft", "PowerToys", "QuickNotes")
                     : customPath;
-                    
-                var powerToysPath = Path.Combine(appDataPath, "Microsoft", "PowerToys", "QuickNotes");
+                
                 if (!Directory.Exists(powerToysPath))
                     Directory.CreateDirectory(powerToysPath);
 


### PR DESCRIPTION
**This PR is a fix to the custom notes path feature.**

## Fix

When defining a custom path via the `QUICKNOTES_CUSTOM_PATH` environment variable, the plugin was still creating redundant subfolders (`Microsoft/PowerToys/QuickNotes`) inside the specified path.

## What it does

This update ensures that when a custom path is provided, the plugin uses it directly without adding extra subfolders.
The default behavior (using `%LOCALAPPDATA%\Microsoft\PowerToys\QuickNotes`) remains unchanged when the variable is not set.